### PR TITLE
feat: use contexts instead of forwarding signals to terminate goroutines

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    name: Build
+    name: Build raw binary
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -12,7 +12,8 @@ jobs:
         with:
           go-version: ">=1.22"
       - run: go version
-      - run: go build -v ./cmd/protrans
+      - run: make all
+      - run: ldd ./protrans
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -22,4 +23,14 @@ jobs:
         with:
           go-version: ">=1.22"
       - run: go version
-      - run: go test -v ./...
+      - run: make test
+  flake:
+    name: Build Flake
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v27
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - run: nix build
+      - run: ldd ./result/bin/protrans

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .direnv/
+protrans

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+GO := $(shell which go)
+VERSION = 1.1
+
+.PHONY: clean
+
+all: protrans
+
+protrans: cmd/protrans/main.go
+	$(GO) build -ldflags "-X 'main.Version=${VERSION}'" -o $@ -v $^
+
+test:
+	$(GO) test -v ./...
+
+clean:
+	rm -fr protrans

--- a/flake.nix
+++ b/flake.nix
@@ -5,20 +5,26 @@
     let
       system = "x86_64-linux";
       pkgs = import nixpkgs { inherit system; };
+      hardeningDisable = [ "fortify" ];
+      version = "1.1";
     in
     {
       devShells.${system}.default = pkgs.mkShell {
+        inherit hardeningDisable;
         packages = with pkgs; [ go ];
-        hardeningDisable = [ "fortify" ];
       };
 
       packages.${system}.default = pkgs.buildGoModule {
+        inherit hardeningDisable version;
         pname = "protrans";
-        version = "1.0";
-        hardeningDisable = [ "fortify" ];
 
-        src = ./.;
+        src =
+          let
+            noSrcs = [ ".vscode" ".git" ".github" ".gitignore" ".envrc" ];
+          in
+          builtins.filterSource (path: _: ! builtins.elem (baseNameOf path) noSrcs) ./.;
 
+        ldflags = [ "-X 'main.Version=${version}'" ];
         vendorHash = "sha256-H79018dCud68fYT0l3IGZXQvD22byhnw/GchsiYJc68=";
       };
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,7 @@ type (
 func overrideWithEnvironment(iface, concrete any) {
 	types := reflect.TypeOf(iface)
 	values := reflect.ValueOf(concrete).Elem()
+
 	for i := 0; i < types.NumField(); i++ {
 		typeField := types.Field(i)
 		valueField := values.FieldByName(typeField.Name)


### PR DESCRIPTION
Other minor modifications include:
- Build flake in GitHub CI
- Makefile to simplify the commands
- Better versioning
- Clean flake.nix file a little